### PR TITLE
Automatically test that syntax-rs is unchanged

### DIFF
--- a/tests/syntax-rs-unchanged.rs
+++ b/tests/syntax-rs-unchanged.rs
@@ -1,0 +1,14 @@
+//! Testing ../examples/syntax.rs
+
+use verusfmt::parse_and_format;
+
+/// Just an automatic test to make sure that ../examples/syntax.rs is left unchanged by verusfmt.
+///
+/// This is essentially intended to be a snapshot test, like ./snap-tests.rs, but only as a quick
+/// indicator for whether `syntax.rs` has been modified by any change, in order to ensure that
+/// `syntax.rs` always in sync with the output that would show up from verusfmt.
+#[test]
+fn syntax_rs_unchanged() {
+    let syntax_rs = include_str!("../examples/syntax.rs").to_owned();
+    assert_eq!(parse_and_format(&syntax_rs), Ok(syntax_rs));
+}


### PR DESCRIPTION
As noted in https://github.com/jaybosamiya/verusfmt/pull/4#issuecomment-1799812203, manual sanity checking of whether `syntax.rs` passes is being done. This PR automates that by adding that check to the test suite.