### PR TITLE
fix extra spaces in if-expr with bool negation

### DIFF
--- a/tests/rustfmt-matching.rs
+++ b/tests/rustfmt-matching.rs
@@ -282,6 +282,9 @@ fn test_function() {
     if arg.len() < 12 {
         return 5;
     }
+    if !b {
+        return 5;
+    }
     extend_vec_u8();
     if y {
         1


### PR DESCRIPTION
Currently, verusfmt adds a space for each 'condition' node. However, the grammar is set up so that this has _two_ condition nodes:

```
if !b {
}
```

so it ends up formatted as:

```
if !b  {
}
```

See the expansion has two 'condition' nodes:

```
if_expr {
                  if_str {}
                  condition {
                    bang_str {}
                    condition {
                      expr_no_struct {
                        path_expr_no_generics {
                          path_no_generics {
                            path_segment_no_generics {
                              name_ref {
                                identifier {}
                              }
                            }
                          }
                        }
                      }
                    }
                  }
```

The PR changes the handling of the space to be with an 'if' expression or 'while' expression, rather than having it handled with the 'condition' node. 