### PR TITLE
Handle macro-call statements

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -727,6 +727,7 @@ fn to_doc<'a>(
         Rule::lifetime_arg => map_to_doc(ctx, arena, pair),
         Rule::const_arg => unsupported(pair),
         Rule::macro_call => s,
+        Rule::macro_call_stmt => s,
         Rule::punctuation => map_to_doc(ctx, arena, pair),
         Rule::token => map_to_doc(ctx, arena, pair),
         Rule::delim_token_tree => map_to_doc(ctx, arena, pair),

--- a/src/verus.pest
+++ b/src/verus.pest
@@ -464,6 +464,20 @@ macro_call = {
     attr* ~ path ~ bang_str ~ !"=" ~ token_tree
 }
 
+// NOTE: By convention, stmt-like or item-like macros (e.g., calc!{}) tend to
+// use curly braces; this is only a convention though, and _technically_ one
+// could use parens or square brackets for the same. However, we use this to
+// disambiguate unknown macros when used in statement lists _without_
+// semi-colons; if it is intended as an expr, the user better be using parens.
+//
+// Another alternative is to use `!(expr ~ "}") ~ macro_call` rather than
+// `macro_call_stmt`, but as of now, I believe this to be a better choice; we
+// can switch to the alternative if we find situations where it might be better
+// suited.
+macro_call_stmt = {
+    attr* ~ path ~ bang_str ~ !"=" ~ lbrace_str ~ token_tree* ~ rbrace_str
+}
+
 // See https://doc.rust-lang.org/beta/reference/tokens.html#punctuation
 punctuation = {
     bin_expr_ops
@@ -869,6 +883,7 @@ stmt = {
   | expr_with_block ~ semi_str?
   | expr ~ semi_str
   | item_no_macro_call
+  | macro_call_stmt
 }
 
 let_stmt = {

--- a/tests/verus-consistency.rs
+++ b/tests/verus-consistency.rs
@@ -458,6 +458,59 @@ verus!{
 }
 
 #[test]
+fn verus_macro_statements() {
+    let file = r#"
+verus! {
+
+// Notice that the semicolon is optional
+proof fn foo() {
+    calc! {
+        (==)
+        1int; {}
+        (0int + 1int); {}
+    };
+    calc! {
+        (==)
+        1int; {}
+        (0int + 1int); {}
+    }
+    calc! {
+        (==)
+        1int; {}
+        (0int + 1int); {}
+    }
+}
+
+}
+"#;
+
+    assert_snapshot!(parse_and_format(file).unwrap(), @r###"
+    verus! {
+
+    // Notice that the semicolon is optional
+    proof fn foo() {
+        calc! {
+            (==)
+            1int; {}
+            (0int + 1int); {}
+        };
+        calc! {
+            (==)
+            1int; {}
+            (0int + 1int); {}
+        }
+        calc! {
+            (==)
+            1int; {}
+            (0int + 1int); {}
+        }
+    }
+
+    } // verus!
+    "###);
+}
+
+#[test]
 fn verus_impl() {
     let file = r#"
 verus! {


### PR DESCRIPTION
Some macros, such as `calc!{}` can sit in statement position and need not have a terminating semicolon. This would previously be rejected by the parser, requiring the extra semicolon to not misparse whatever came _after_ such a statement-position macro-call.

By convention, such macro calls use curly braces (while expr ones tend to use square or parens), so we can use this as a disambiguating factor. More details in parser comment.